### PR TITLE
[TIMOB-10234]KitchenSink: Platform > XHR > File Download: 'Large File Download' after downloading file leads to crash.

### DIFF
--- a/Resources/ui/common/platform/xhr_filedownload.js
+++ b/Resources/ui/common/platform/xhr_filedownload.js
@@ -157,8 +157,9 @@ function xhr_download() {
 		{
 			Ti.UI.createAlertDialog({title:'XHR', message:'Error: ' + e.error}).show();
 		};
-	
+		
 		c.open('GET','http://titanium-studio.s3.amazonaws.com/latest/Titanium_Studio.exe');
+		c.file = Titanium.Filesystem.getFile(Titanium.Filesystem.applicationDataDirectory,'tiStudio.exe');
 		c.send();
 	});
 	


### PR DESCRIPTION
Test case in [Jira](https://jira.appcelerator.org/browse/TIMOB-10234).

**NOTE**
Donot resolve the jira ticket, there is still a bug in our platform that needs to be tracked through that ticket. This fix is just to make KitchenSink run properly 
