### PR TITLE
[TIMOB-10127]Hiding Keyboard when moving away from searchBar.

### DIFF
--- a/Resources/ui/common/baseui/table_view_headers.js
+++ b/Resources/ui/common/baseui/table_view_headers.js
@@ -68,6 +68,12 @@ function tv_headers() {
 	var search = Titanium.UI.createSearchBar({
 		showCancel:false
 	});
+	search.addEventListener('blur',function(){
+		if(Ti.Platform.name === "android"){
+			Ti.API.info('Going to hide soft Keyboard as we are shifting focus away from the SearchBar.');
+			Ti.UI.Android.hideSoftKeyboard();
+		}	
+	});
 	// create table view
 	var tableview = Titanium.UI.createTableView({
 		data:data,


### PR DESCRIPTION
Test case in [JIRA](https://jira.appcelerator.org/browse/TIMOB-10127)

The native android behavior is to move from current focused view to the next focusable view which in this case would be a tableview. So added logic to hide keyboard when searchBar loses focus. 
