### PR TITLE
timob-10310: KitchenSink: Base UI > Views > View Gestures: There is no Titanium ribbon image

### DIFF
--- a/Resources/ui/handheld/ios/baseui/view_gestures.js
+++ b/Resources/ui/handheld/ios/baseui/view_gestures.js
@@ -68,7 +68,7 @@ function view_gestures() {
 	//////////
 	
 	var webview = Ti.UI.createWebView({
-		url:'local_webview_pinchzoom.html',
+		url:'/etc/local_webview_pinchzoom.html',
 		height:160,
 		width:200,
 		top:220


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-10310
This PR fixes the url for the webview. But the image is still missing because the link to that image is no longer valid. Will fix the issue for those invalid links later.
